### PR TITLE
Fixes a call to a service => 'entity.manager' and not 'entity_manager'

### DIFF
--- a/src/Plugin/MediaEntity/Type/YouTube.php
+++ b/src/Plugin/MediaEntity/Type/YouTube.php
@@ -80,7 +80,7 @@ class YouTube extends MediaTypeBase {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('entity_manager'),
+      $container->get('entity.manager'),
       $container->get('config.factory')
     );
   }


### PR DESCRIPTION
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: "You have requested a non-existent service "entity_manager". Did you mean this: "entity.manager"?"
error while trying to add a media bundle
